### PR TITLE
updating reader to zarr3

### DIFF
--- a/code/aind_z1_radial_correction/__init__.py
+++ b/code/aind_z1_radial_correction/__init__.py
@@ -1,6 +1,6 @@
 """Z1 radial correction."""
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 __authors__ = ["Camilo Laiton", "Carson Berry", "Tim Wang"]
 __author_emails__ = [
     "camilo.laiton@alleninstitute.org",

--- a/code/aind_z1_radial_correction/array_to_zarr.py
+++ b/code/aind_z1_radial_correction/array_to_zarr.py
@@ -20,13 +20,13 @@ from aind_hcr_data_transformation.utils.utils import pad_array_n_d
 from numcodecs.blosc import Blosc
 from numpy.typing import ArrayLike
 from ome_zarr.io import parse_url
-from zarr.storage import FSStore
 from zarr.errors import ContainsGroupError
+from zarr.storage import FSStore
 
 from .utils.utils import get_parent_path, is_s3_path
 
 
-def safe_create_zarr_group(store, path: str = '', **kwargs):
+def safe_create_zarr_group(store, path: str = "", **kwargs):
     """
     Safe creation of the zarr group.
 
@@ -47,7 +47,8 @@ def safe_create_zarr_group(store, path: str = '', **kwargs):
         return zarr.group(store=store, path=path, overwrite=False, **kwargs)
     except ContainsGroupError:
         # Group already exists, which is expected with multiple workers
-        return zarr.open_group(store=store, path=path, mode='r+')
+        return zarr.open_group(store=store, path=path, mode="r+")
+
 
 def convert_array_to_zarr(
     array: ArrayLike,
@@ -139,7 +140,7 @@ def convert_array_to_zarr(
     # Ideally we would use da.percentile(image_data, (0.1, 95))
     # However, it would take so much time and resources and it is
     # not used that much on neuroglancer
-    channel_startend = [(0.0, 550.0) for _ in range(dataset_shape[1])]
+    channel_startend = [(90.0, 1200.0) for _ in range(dataset_shape[1])]
 
     # Writing OME-NGFF metadata
     scale_factor = [int(s) for s in scale_factor]

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -4,6 +4,7 @@ to the data directory
 """
 
 import os
+import sys
 from pathlib import Path
 
 from aind_z1_radial_correction import radial_correction
@@ -14,6 +15,14 @@ def run():
     """
     Main run file in Code Ocean
     """
+    if len(sys.argv) < 3:
+        print("Usage: run_capsule.py <int_write_to_s3>")
+        sys.exit(1)
+
+    TENSORSTORE_DRIVER = "zarr3"
+    write_to_s3 = bool(int(sys.argv[1]))
+    sys.argv = [sys.argv[0]]
+
     data_folder = os.path.abspath("../data")
     results_folder = os.path.abspath("../results")
 
@@ -44,14 +53,6 @@ def run():
         radial_correction_parameters_path
     )
 
-    data_description = utils.read_json_as_dict(data_description_path)
-
-    dataset_name = data_description.get("name", {})
-    if not dataset_name:
-        raise ValueError(
-            f"Dataset name not found in data_description.json: {data_description_path}"
-        )
-
     tilenames = radial_correction_parameters.get("tilenames", [])
     worker_id = radial_correction_parameters.get("worker_id", None)
     bucket_name = radial_correction_parameters.get("bucket_name", None)
@@ -62,7 +63,14 @@ def run():
     print(f"Worker ID: {worker_id} processing {len(tilenames)} tiles!")
 
     write_folder = results_folder
-    if bucket_name is not None:
+    if bucket_name is not None and write_to_s3:
+        data_description = utils.read_json_as_dict(data_description_path)
+        dataset_name = data_description.get("name", None)
+        if not dataset_name:
+            raise ValueError(
+                f"Dataset name not found in data_description.json: {data_description_path}"
+            )
+
         write_folder = (
             f"s3://{bucket_name}/{dataset_name}/image_radial_correction"
         )
@@ -76,6 +84,7 @@ def run():
             results_folder=write_folder,
             acquisition_path=acquisition_path,
             tilenames=tilenames,
+            driver=TENSORSTORE_DRIVER,
         )
 
         # Write the output path to a file

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -15,13 +15,6 @@ def run():
     """
     Main run file in Code Ocean
     """
-    if len(sys.argv) < 3:
-        print("Usage: run_capsule.py <int_write_to_s3>")
-        sys.exit(1)
-
-    TENSORSTORE_DRIVER = "zarr3"
-    write_to_s3 = bool(int(sys.argv[1]))
-    sys.argv = [sys.argv[0]]
 
     data_folder = os.path.abspath("../data")
     results_folder = os.path.abspath("../results")
@@ -39,7 +32,7 @@ def run():
     required_input_elements = [
         acquisition_path,
         radial_correction_parameters_path,
-        data_description_path,
+        # data_description_path,
     ]
 
     missing_files = utils.validate_capsule_inputs(required_input_elements)
@@ -59,6 +52,10 @@ def run():
     input_s3_dataset_path = radial_correction_parameters.get(
         "input_s3_dataset_path", None
     )
+    tensorstore_driver = radial_correction_parameters.get(
+        "tensorstore_driver", "zarr3"
+    )
+    write_to_s3 = radial_correction_parameters.get("write_to_s3", True)
 
     print(f"Worker ID: {worker_id} processing {len(tilenames)} tiles!")
 
@@ -84,7 +81,7 @@ def run():
             results_folder=write_folder,
             acquisition_path=acquisition_path,
             tilenames=tilenames,
-            driver=TENSORSTORE_DRIVER,
+            driver=tensorstore_driver,
         )
 
         # Write the output path to a file

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -32,7 +32,7 @@ def run():
     required_input_elements = [
         acquisition_path,
         radial_correction_parameters_path,
-        # data_description_path,
+        data_description_path,
     ]
 
     missing_files = utils.validate_capsule_inputs(required_input_elements)


### PR DESCRIPTION
Adding functionality to read zarr v3 or v2 as needed. However, by default it is set to zarr v3 since the data transfer service is using v3 by default now.

I still need to write unit tests for this package. Should we do it as a different ticket?