### PR TITLE
Updating workflows

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -3,9 +3,7 @@ on:
   push:
     branches:
       - main
-# Remove line 61 to enable automated semantic version bumps.
-# Change line 67 from "if: false" to "if: true" to enable PyPI publishing. 
-# Requires that svc-aindscicomp be added as an admin to repo.
+
 jobs:
   update_badges:
     runs-on: ubuntu-latest
@@ -16,10 +14,10 @@ jobs:
         ref: ${{ env.DEFAULT_BRANCH }}
         fetch-depth: 0
         token: ${{ secrets.SERVICE_TOKEN }}
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install dependencies
       run: | 
         python -m pip install -e .[dev] --no-cache-dir
@@ -60,12 +58,14 @@ jobs:
         default_author: github_actions
         message: "ci: update badges [skip actions]"
         add: '["README.md"]'
+
   tag:
     needs: update_badges
-    if: ${{github.event.repository.name == 'aind-library-template'}}
+    if: ${{ github.event.repository.name == 'aind-library-template' }}
     uses: AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main
     secrets:
       SERVICE_TOKEN: ${{ secrets.SERVICE_TOKEN }}
+
   publish:
     needs: tag
     if: false
@@ -74,10 +74,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Pull latest changes
         run: git pull origin main
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install --upgrade setuptools wheel twine build

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.10' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This PR fixes the workflows to use only python 3.10. This is necessary since we use the [aind-hcr-data-transformation ](https://github.com/AllenNeuralDynamics/aind-hcr-data-transformation) dependency. This package works in python 3.10>. I didn't upgrade the code version since nothing change in the base code but in the workflows.